### PR TITLE
Fix model inheritance cases.

### DIFF
--- a/lib/built-in-models.json
+++ b/lib/built-in-models.json
@@ -1,0 +1,10 @@
+[
+  "AccessToken",
+  "Application",
+  "Role",
+  "RoleMapping",
+  "Scope",
+  "User",
+  "UserCredential",
+  "UserIdentity"
+]

--- a/lib/pancake.js
+++ b/lib/pancake.js
@@ -255,16 +255,7 @@ class Pancake {
       // if metadata is not defined, skip this build
       return;
     }
-    const properties = {
-      'createdAt': {
-        'type': 'Date',
-        'defaultFn': 'now',
-      },
-      'modifiedAt': {
-        'type': 'Date',
-        'defaultFn': 'now',
-      },
-    };
+    const properties = {};
     const indexes = {};
     const security = {
       _: '',  // for all fields
@@ -272,10 +263,20 @@ class Pancake {
 
     let plural, baseModel;
     if (!isEmbeddable) {
-      if (metadata.base === 'PersistedModel') {
-        plural = Utils.pluralize(metadata.name);
-      } else {
+      switch (metadata.base) {
+      case 'AccessToken':
+      case 'Application':
+      case 'Role':
+      case 'RoleMapping':
+      case 'Scope':
+      case 'User':
+      case 'UserCredential':
+      case 'UserIdentity':
+        // overriding base models shipped with Loopback
         plural = Utils.pluralize(metadata.base);
+        break;
+      default:
+        plural = Utils.pluralize(metadata.name);
       }
       baseModel = metadata.base;
     } else {

--- a/lib/pancake.js
+++ b/lib/pancake.js
@@ -9,6 +9,7 @@ const Fs = require('fs');
 const Path = require('path');
 const sourceTmpl = Fs.readFileSync(
   Path.join(__dirname, './source.template.js'));
+const builtInModels = require('./built-in-models.json');
 
 function readConfig(pathname) {
   try {
@@ -263,19 +264,10 @@ class Pancake {
 
     let plural, baseModel;
     if (!isEmbeddable) {
-      switch (metadata.base) {
-      case 'AccessToken':
-      case 'Application':
-      case 'Role':
-      case 'RoleMapping':
-      case 'Scope':
-      case 'User':
-      case 'UserCredential':
-      case 'UserIdentity':
+      if (builtInModels.indexOf(metadata.base) >= 0) {
         // overriding base models shipped with Loopback
         plural = Utils.pluralize(metadata.base);
-        break;
-      default:
+      } else {
         plural = Utils.pluralize(metadata.name);
       }
       baseModel = metadata.base;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@
  */
 
 const Inflection = require('inflection');
+const builtInModels = require('./built-in-models.json');
 
 /**
  *
@@ -44,17 +45,9 @@ function pluralize2(name) {
  */
 function getModelName(model) {
   let newName;
-  switch (model.base) {
-  case 'AccessToken':
-  case 'Application':
-  case 'Role':
-  case 'RoleMapping':
-  case 'Scope':
-  case 'User':
-  case 'UserCredential':
-  case 'UserIdentity':
+  if (builtInModels.indexOf(models.base) >= 0) {
     return pluralize(model.base);
-  default:
+  } else {
     return pluralize(model.name);
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,7 +45,7 @@ function pluralize2(name) {
  */
 function getModelName(model) {
   let newName;
-  if (builtInModels.indexOf(models.base) >= 0) {
+  if (builtInModels.indexOf(model.base) >= 0) {
     return pluralize(model.base);
   } else {
     return pluralize(model.name);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,13 +44,19 @@ function pluralize2(name) {
  */
 function getModelName(model) {
   let newName;
-  if (model.base === 'PersistedModel' ||
-    model.base === 'Model') {
-    newName = pluralize(model.name);
-  } else {
-    newName = pluralize(model.base);
+  switch (model.base) {
+  case 'AccessToken':
+  case 'Application':
+  case 'Role':
+  case 'RoleMapping':
+  case 'Scope':
+  case 'User':
+  case 'UserCredential':
+  case 'UserIdentity':
+    return pluralize(model.base);
+  default:
+    return pluralize(model.name);
   }
-  return newName;
 }
 
 exports.pluralize = pluralize;


### PR DESCRIPTION
R= @yorkie 

**Abstract**
Prior to this commit, Pancake would assume that client won't extend
user-defined models, resulting unintuitive outputs.

---

For example, if I define a model `MyAbstractModel`,

```
#+NAME: MyAbstractModel
| attr  | type                        | default | required | security  |
|-------+-----------------------------+---------+----------+-----------|
| value | Number                      | 0       | false    | rw-rw-r-- |
```

and then I create another model, `MyPersistedModel`, to inherit from MyAbstractMode,

```
#+NAME: MyPersistedModel
#+BASE: MyAbstractModel
| attr  | type                        | default | required | security  |
|-------+-----------------------------+---------+----------+-----------|
| key   | String                      | 0       | false    | rw-rw-r-- |
```

Then oddly, the plural form of MyPersistedModel would be _MyAbstractedModels_, and this is very confusing and unintuitive.

In this PullRequest, I managed to inherit (and override) built-in Models from Loopback, and allow user to inherit from a custom-defined base class.
